### PR TITLE
Snlbattery 29 Implementing Parameters Dropdown with Actions 

### DIFF
--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -4,15 +4,17 @@ import { Section, Input, Checkbox } from "@/components/visualizations/editor";
 import Button from "antd/lib/button";
 import { useState } from "react";
 import { EditorPropTypes } from "@/visualizations/prop-types";
+import DeleteOutlinedIcon from "@ant-design/icons/DeleteOutlined"
+import { useEffect } from "react";
 
 type Props = {
   options: {
     buttonArr: any[]
   };
-  onChange: (...args: any[]) => any;
+  onOptionsChange: (...args: any[]) => any;
 };
 const ButtonSettings = ({options, onOptionsChange }: Props) => {
-  const [arr, setArr]: any[] = useState(options.buttonArr ? options.buttonArr :[{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+  const [arr, setArr]: any[] = useState(options.buttonArr ? options.buttonArr : [{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
   const handleChange = (event: any, item: any) => {
     if (event.target.id === "Button-Name") {
       item.name = event.target.value;
@@ -28,8 +30,22 @@ const ButtonSettings = ({options, onOptionsChange }: Props) => {
   };
   const addButton = () => {
     const buttonArr = arr
+    console.log('buttonArr', buttonArr)
     onOptionsChange({buttonArr})
   }
+  const deleteButton = (button: any) => {
+    const buttonArr = [...arr]
+    const newArr = buttonArr.filter((item: any) => item !== button);
+    setArr(newArr)
+    console.log('arr', buttonArr)
+    onOptionsChange({buttonArr})
+  }
+
+  useEffect(() => {
+    const buttonArr = arr
+    onOptionsChange({buttonArr})
+  }, [arr])
+
   return (
     <>
       <Button onClick={createInputs}>Add Action</Button>
@@ -66,6 +82,12 @@ const ButtonSettings = ({options, onOptionsChange }: Props) => {
                 onChange={event => handleChange(event, item)}>
                 Open in new tab
               </Checkbox>
+            </Section>
+            {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+            <Section>
+              <Button onClick={() => deleteButton(item)}>
+                <DeleteOutlinedIcon/>
+              </Button>
             </Section>
           </React.Fragment>
         );

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -5,21 +5,30 @@ import { Section, Input, Checkbox } from "@/components/visualizations/editor";
 import { EditorPropTypes } from "@/visualizations/prop-types";
 import Button from "antd/lib/button";
 import { useState, useEffect } from "react";
+import Item from "antd/lib/list/Item";
 
 type Props = {
   options: {
-    buttonName: string;
-    buttonLinkUrlTemplate?: string;
-    buttonLinkOpenInNewTab?: boolean;
+    name: string;
+    linkUrlTemplate?: string;
+    linkOpenInNewTab?: boolean;
   };
   onChange: (...args: any[]) => any;
 };
 
-export default function ButtonSettings({ onChange }: Props) {
-  const [arr, setArr]: any[] = useState([]);
-  function handleChange(item: any, checked: any) {
-    item.linkOpenInNewTab = checked;
-  }
+const ButtonSettings = ({ onChange }: Props) => {
+  const [arr, setArr]: any[] = useState([{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+  const handleChange = (event: any, item: any) => {
+    console.log(event.target, item);
+    if (event.target.id === "Button-Name") {
+      item.name = event.target.value;
+    } else if (event.target.id === "URL-Template") {
+      item.linkUrlTemplate = event.target.value;
+    } else if (event.target.type === "checkbox") {
+      item.linkOpenInNewTab = event.target.checked;
+    }
+    setArr((prevArr: any) => [...prevArr]);
+  };
   const [onChangeDebounced] = useDebouncedCallback(onChange, 200);
   const [test, setTest]: any[] = useState([]);
   const [options, setOptions]: any[] = useState([]);
@@ -30,61 +39,52 @@ export default function ButtonSettings({ onChange }: Props) {
     console.log("arr", arr);
   };
 
-  useEffect(() => {
-    const newArr: any = [];
-
-    arr.forEach((item: any, index: any) => {
-      const newItem = (
-        <React.Fragment key={index}>
-          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-          <Section key={index} item={item}>
-            <Input
-              label="Button Name"
-              // data-test="Table.ColumnEditor.Link.Name"
-              defaultValue={item.name}
-              onChange={(event: any) => onChangeDebounced({ buttonName: event.target.value })}
-            />
-          </Section>
-          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-          <Section>
-            <Input
-              label="URL template"
-              // data-test="Table.ColumnEditor.Link.UrlTemplate"
-              defaultValue={item.linkUrlTemplate}
-              onChange={(event: any) => onChangeDebounced({ buttonLinkUrlTemplate: event.target.value })}
-            />
-          </Section>
-
-          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-          <Section>
-            <Checkbox
-              // data-test="Table.ColumnEditor.Link.OpenInNewTab"
-              value={item.linkOpenInNewTab}
-              checked={item.linkOpenInNewTab}
-              onChange={event => {
-                item.linkOpenInNewTab = event.target.checked;
-                console.log(item.linkOpenInNewTab);
-                return item.linkOpenInNewTab;
-              }}>
-              Open in new tab
-            </Checkbox>
-          </Section>
-        </React.Fragment>
-      );
-      newArr.push(newItem);
-    });
-
-    setTest(newArr);
-  }, [arr]);
-
   return (
     <>
       <Button onClick={doSomething}>Do Something</Button>
-      {test}
+      {map(arr, (item: any, index: any) => {
+        return (
+          <React.Fragment key={index}>
+            {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+            <Section key={index} item={item}>
+              <Input
+                label="Button Name"
+                id="Button-Name"
+                // data-test="Table.ColumnEditor.Link.Name"
+                defaultValue={item.name}
+                onChange={(event: any) => handleChange(event, item)}
+              />
+            </Section>
+            {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+            <Section>
+              <Input
+                label="URL template"
+                id="URL-Template"
+                // data-test="Table.ColumnEditor.Link.UrlTemplate"
+                defaultValue={item.linkUrlTemplate}
+                onChange={(event: any) => handleChange(event, item)}
+              />
+            </Section>
+
+            {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+            <Section>
+              <Checkbox
+                // data-test="Table.ColumnEditor.Link.OpenInNewTab"
+                value={item.linkOpenInNewTab}
+                checked={item.linkOpenInNewTab}
+                onChange={event => handleChange(event, item)}>
+                Open in new tab
+              </Checkbox>
+            </Section>
+          </React.Fragment>
+        );
+      })}
     </>
   );
-}
+};
 
 ButtonSettings.defaultProps = {
   onChange: () => {},
 };
+
+export default ButtonSettings;

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -1,0 +1,80 @@
+import { map } from "lodash";
+import React from "react";
+import { useDebouncedCallback } from "use-debounce";
+import { Section, Input, Checkbox } from "@/components/visualizations/editor";
+import { EditorPropTypes } from "@/visualizations/prop-types";
+import Button from "antd/lib/button";
+import { useState, useEffect } from "react";
+
+type Props = {
+  options: {
+    buttonName: string;
+    buttonLinkUrlTemplate?: string;
+    buttonLinkOpenInNewTab?: boolean;
+  };
+  onChange: (...args: any[]) => any;
+};
+
+export default function ButtonSettings({onChange }: Props) {
+  const [arr, setArr]: any[] = useState([])
+  function handleChange(changes: any) {
+    console.log('options', options)
+    console.log('changes', changes)
+    // onChange({ ...options, ...changes });
+
+  }
+  const [onChangeDebounced] = useDebouncedCallback(onChange, 200);
+  const [test, setTest]: any[] = useState([])
+  const [options, setOptions]: any[] = useState([])
+
+  const doSomething = () => {
+    // arr.push({name: "", linkUrlTemplate: "", linkOpenInNewTab: false})
+    setArr((prevArr: any) => [...prevArr, {name: "", linkUrlTemplate: "", linkOpenInNewTab: false}])
+    console.log('arr', arr)
+  }
+
+useEffect(() => {arr.forEach((item, index) => {
+  setTest((prevState:any) =>[...prevState, 
+<React.Fragment key={index}>
+  {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+  <Section>
+        <Input
+          label="Button Name"
+          data-test="Table.ColumnEditor.Link.Name"
+          defaultValue={item.name}
+          onChange={(event: any) => onChangeDebounced({ buttonName: event.target.value })}
+        />
+      </Section>
+      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+      <Section>
+        <Input
+          label="URL template"
+          data-test="Table.ColumnEditor.Link.UrlTemplate"
+          defaultValue={item.linkUrlTemplate}
+          onChange={(event: any) => onChangeDebounced({ buttonLinkUrlTemplate: event.target.value })}
+        />
+      </Section>
+
+      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+      <Section>
+        <Checkbox
+          data-test="Table.ColumnEditor.Link.OpenInNewTab"
+          checked={item.linkOpenInNewTab}
+          onChange={event => handleChange({ linkOpenInNewTab: event.target.checked })}>
+          Open in new tab
+        </Checkbox>
+      </Section>
+    </React.Fragment>]
+  )
+})}, [arr])
+  return (
+    <>
+    <Button onClick={doSomething}>Do Something</Button>
+    {test}
+    </>
+  );
+}
+
+ButtonSettings.defaultProps = {
+  onChange: () => {},
+};

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -1,11 +1,8 @@
 import { map } from "lodash";
 import React from "react";
-import { useDebouncedCallback } from "use-debounce";
 import { Section, Input, Checkbox } from "@/components/visualizations/editor";
-import { EditorPropTypes } from "@/visualizations/prop-types";
 import Button from "antd/lib/button";
-import { useState, useEffect } from "react";
-import Item from "antd/lib/list/Item";
+import { useState } from "react";
 
 type Props = {
   options: {
@@ -18,8 +15,8 @@ type Props = {
 
 const ButtonSettings = ({ onChange }: Props) => {
   const [arr, setArr]: any[] = useState([{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+
   const handleChange = (event: any, item: any) => {
-    console.log(event.target, item);
     if (event.target.id === "Button-Name") {
       item.name = event.target.value;
     } else if (event.target.id === "URL-Template") {
@@ -27,16 +24,12 @@ const ButtonSettings = ({ onChange }: Props) => {
     } else if (event.target.type === "checkbox") {
       item.linkOpenInNewTab = event.target.checked;
     }
+
     setArr((prevArr: any) => [...prevArr]);
   };
-  const [onChangeDebounced] = useDebouncedCallback(onChange, 200);
-  const [test, setTest]: any[] = useState([]);
-  const [options, setOptions]: any[] = useState([]);
 
   const doSomething = () => {
-    // arr.push({name: "", linkUrlTemplate: "", linkOpenInNewTab: false})
     setArr((prevItems: any) => [...prevItems, { name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
-    console.log("arr", arr);
   };
 
   return (

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -15,62 +15,72 @@ type Props = {
   onChange: (...args: any[]) => any;
 };
 
-export default function ButtonSettings({onChange }: Props) {
-  const [arr, setArr]: any[] = useState([])
-  function handleChange(changes: any) {
-    console.log('options', options)
-    console.log('changes', changes)
-    // onChange({ ...options, ...changes });
-
+export default function ButtonSettings({ onChange }: Props) {
+  const [arr, setArr]: any[] = useState([]);
+  function handleChange(item: any, checked: any) {
+    item.linkOpenInNewTab = checked;
   }
   const [onChangeDebounced] = useDebouncedCallback(onChange, 200);
-  const [test, setTest]: any[] = useState([])
-  const [options, setOptions]: any[] = useState([])
+  const [test, setTest]: any[] = useState([]);
+  const [options, setOptions]: any[] = useState([]);
 
   const doSomething = () => {
     // arr.push({name: "", linkUrlTemplate: "", linkOpenInNewTab: false})
-    setArr((prevArr: any) => [...prevArr, {name: "", linkUrlTemplate: "", linkOpenInNewTab: false}])
-    console.log('arr', arr)
-  }
+    setArr((prevItems: any) => [...prevItems, { name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+    console.log("arr", arr);
+  };
 
-useEffect(() => {arr.forEach((item, index) => {
-  setTest((prevState:any) =>[...prevState, 
-<React.Fragment key={index}>
-  {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-  <Section>
-        <Input
-          label="Button Name"
-          data-test="Table.ColumnEditor.Link.Name"
-          defaultValue={item.name}
-          onChange={(event: any) => onChangeDebounced({ buttonName: event.target.value })}
-        />
-      </Section>
-      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-      <Section>
-        <Input
-          label="URL template"
-          data-test="Table.ColumnEditor.Link.UrlTemplate"
-          defaultValue={item.linkUrlTemplate}
-          onChange={(event: any) => onChangeDebounced({ buttonLinkUrlTemplate: event.target.value })}
-        />
-      </Section>
+  useEffect(() => {
+    const newArr: any = [];
 
-      {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-      <Section>
-        <Checkbox
-          data-test="Table.ColumnEditor.Link.OpenInNewTab"
-          checked={item.linkOpenInNewTab}
-          onChange={event => handleChange({ linkOpenInNewTab: event.target.checked })}>
-          Open in new tab
-        </Checkbox>
-      </Section>
-    </React.Fragment>]
-  )
-})}, [arr])
+    arr.forEach((item: any, index: any) => {
+      const newItem = (
+        <React.Fragment key={index}>
+          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <Section key={index} item={item}>
+            <Input
+              label="Button Name"
+              // data-test="Table.ColumnEditor.Link.Name"
+              defaultValue={item.name}
+              onChange={(event: any) => onChangeDebounced({ buttonName: event.target.value })}
+            />
+          </Section>
+          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <Section>
+            <Input
+              label="URL template"
+              // data-test="Table.ColumnEditor.Link.UrlTemplate"
+              defaultValue={item.linkUrlTemplate}
+              onChange={(event: any) => onChangeDebounced({ buttonLinkUrlTemplate: event.target.value })}
+            />
+          </Section>
+
+          {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+          <Section>
+            <Checkbox
+              // data-test="Table.ColumnEditor.Link.OpenInNewTab"
+              value={item.linkOpenInNewTab}
+              checked={item.linkOpenInNewTab}
+              onChange={event => {
+                item.linkOpenInNewTab = event.target.checked;
+                console.log(item.linkOpenInNewTab);
+                return item.linkOpenInNewTab;
+              }}>
+              Open in new tab
+            </Checkbox>
+          </Section>
+        </React.Fragment>
+      );
+      newArr.push(newItem);
+    });
+
+    setTest(newArr);
+  }, [arr]);
+
   return (
     <>
-    <Button onClick={doSomething}>Do Something</Button>
-    {test}
+      <Button onClick={doSomething}>Do Something</Button>
+      {test}
     </>
   );
 }

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -1,20 +1,24 @@
 import { map } from "lodash";
 import React from "react";
-import { Section, Input, Checkbox } from "@/components/visualizations/editor";
+import { Section, Input, Checkbox, Select } from "@/components/visualizations/editor";
 import Button from "antd/lib/button";
 import { useState } from "react";
 import { EditorPropTypes } from "@/visualizations/prop-types";
-import DeleteOutlinedIcon from "@ant-design/icons/DeleteOutlined"
+import DeleteOutlinedIcon from "@ant-design/icons/DeleteOutlined";
 import { useEffect } from "react";
 
 type Props = {
   options: {
-    buttonArr: any[]
+    buttonArr: any[];
+    columns: any[];
   };
   onOptionsChange: (...args: any[]) => any;
 };
-const ButtonSettings = ({options, onOptionsChange }: Props) => {
-  const [arr, setArr]: any[] = useState(options.buttonArr ? options.buttonArr : [{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+const ButtonSettings = ({ options, onOptionsChange }: Props) => {
+  const [arr, setArr]: any[] = useState(
+    options.buttonArr ? options.buttonArr : [{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true, columnName: "" }]
+  );
+
   const handleChange = (event: any, item: any) => {
     if (event.target.id === "Button-Name") {
       item.name = event.target.value;
@@ -23,28 +27,40 @@ const ButtonSettings = ({options, onOptionsChange }: Props) => {
     } else if (event.target.type === "checkbox") {
       item.linkOpenInNewTab = event.target.checked;
     }
+
     setArr((prevArr: any) => [...prevArr]);
   };
-  const createInputs = () => {
-    setArr((prevItems: any) => [...prevItems, { name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
+
+  const handleDropdown = (event: any, item: any) => {
+    if (event) item.columnName = event;
+
+    setArr((prevArr: any) => [...prevArr]);
   };
+
+  const createInputs = () => {
+    setArr((prevItems: any) => [
+      ...prevItems,
+      { name: "", linkUrlTemplate: "", linkOpenInNewTab: true, columnName: "" },
+    ]);
+  };
+
   const addButton = () => {
-    const buttonArr = arr
-    console.log('buttonArr', buttonArr)
-    onOptionsChange({buttonArr})
-  }
+    const buttonArr = arr;
+    console.log("buttonArr", buttonArr);
+    onOptionsChange({ buttonArr });
+  };
   const deleteButton = (button: any) => {
-    const buttonArr = [...arr]
+    const buttonArr = [...arr];
     const newArr = buttonArr.filter((item: any) => item !== button);
-    setArr(newArr)
-    console.log('arr', buttonArr)
-    onOptionsChange({buttonArr})
-  }
+    setArr(newArr);
+    console.log("arr", buttonArr);
+    onOptionsChange({ buttonArr });
+  };
 
   useEffect(() => {
-    const buttonArr = arr
-    onOptionsChange({buttonArr})
-  }, [arr])
+    const buttonArr = arr;
+    onOptionsChange({ buttonArr });
+  }, [arr]);
 
   return (
     <>
@@ -75,6 +91,19 @@ const ButtonSettings = ({options, onOptionsChange }: Props) => {
             </Section>
             {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
             <Section>
+              <Select
+                label="Parameters"
+                id="Column-Dropdown"
+                // data-test="Table.ColumnEditor.Link.UrlTemplate"
+                defaultValue={item.columnName}
+                onChange={(event: any) => handleDropdown(event, item)}>
+                {options.columns.map((column: any) => (
+                  <Select.Option key={column.name}>{column.name}</Select.Option>
+                ))}
+              </Select>
+            </Section>
+            {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
+            <Section>
               <Checkbox
                 // data-test="Table.ColumnEditor.Link.OpenInNewTab"
                 value={item.linkOpenInNewTab}
@@ -86,7 +115,7 @@ const ButtonSettings = ({options, onOptionsChange }: Props) => {
             {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
             <Section>
               <Button onClick={() => deleteButton(item)}>
-                <DeleteOutlinedIcon/>
+                <DeleteOutlinedIcon />
               </Button>
             </Section>
           </React.Fragment>

--- a/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/ButtonSettings.tsx
@@ -3,19 +3,16 @@ import React from "react";
 import { Section, Input, Checkbox } from "@/components/visualizations/editor";
 import Button from "antd/lib/button";
 import { useState } from "react";
+import { EditorPropTypes } from "@/visualizations/prop-types";
 
 type Props = {
   options: {
-    name: string;
-    linkUrlTemplate?: string;
-    linkOpenInNewTab?: boolean;
+    buttonArr: any[]
   };
   onChange: (...args: any[]) => any;
 };
-
-const ButtonSettings = ({ onChange }: Props) => {
-  const [arr, setArr]: any[] = useState([{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
-
+const ButtonSettings = ({options, onOptionsChange }: Props) => {
+  const [arr, setArr]: any[] = useState(options.buttonArr ? options.buttonArr :[{ name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
   const handleChange = (event: any, item: any) => {
     if (event.target.id === "Button-Name") {
       item.name = event.target.value;
@@ -24,17 +21,19 @@ const ButtonSettings = ({ onChange }: Props) => {
     } else if (event.target.type === "checkbox") {
       item.linkOpenInNewTab = event.target.checked;
     }
-
     setArr((prevArr: any) => [...prevArr]);
   };
-
-  const doSomething = () => {
+  const createInputs = () => {
     setArr((prevItems: any) => [...prevItems, { name: "", linkUrlTemplate: "", linkOpenInNewTab: true }]);
   };
-
+  const addButton = () => {
+    const buttonArr = arr
+    onOptionsChange({buttonArr})
+  }
   return (
     <>
-      <Button onClick={doSomething}>Do Something</Button>
+      <Button onClick={createInputs}>Add Action</Button>
+      <Button onClick={addButton}>Add Button To Table</Button>
       {map(arr, (item: any, index: any) => {
         return (
           <React.Fragment key={index}>
@@ -58,7 +57,6 @@ const ButtonSettings = ({ onChange }: Props) => {
                 onChange={(event: any) => handleChange(event, item)}
               />
             </Section>
-
             {/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
             <Section>
               <Checkbox
@@ -75,9 +73,5 @@ const ButtonSettings = ({ onChange }: Props) => {
     </>
   );
 };
-
-ButtonSettings.defaultProps = {
-  onChange: () => {},
-};
-
+ButtonSettings.defaultProps = EditorPropTypes;
 export default ButtonSettings;

--- a/viz-lib/src/visualizations/selection-table/Editor/index.tsx
+++ b/viz-lib/src/visualizations/selection-table/Editor/index.tsx
@@ -2,10 +2,12 @@ import createTabbedEditor from "@/components/visualizations/editor/createTabbedE
 
 import ColumnsSettings from "./ColumnsSettings";
 import GridSettings from "./GridSettings";
+import ButtonSettings from "./ButtonSettings";
 
 import "./editor.less";
 
 export default createTabbedEditor([
   { key: "Columns", title: "Columns", component: ColumnsSettings },
   { key: "Grid", title: "Grid", component: GridSettings },
+  { key: "Action", title: "Action", component: ButtonSettings},
 ]);

--- a/viz-lib/src/visualizations/selection-table/Renderer.tsx
+++ b/viz-lib/src/visualizations/selection-table/Renderer.tsx
@@ -7,7 +7,6 @@ import Popover from "antd/lib/popover";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 import { formatSimpleTemplate } from "@/lib/value-format";
 
-
 import { prepareColumns, initRows, filterRows, sortRows } from "./utils";
 
 import "./renderer.less";
@@ -123,10 +122,10 @@ export default function Renderer({ options, data }: any) {
     let column: Record<string, any> = {};
     let prepared = { rows: rows };
 
-
     options.columns.forEach((optionColumn: Record<string, any>) => {
-      if (optionColumn.linkUrlTemplate !== "{{ @ }}") {
+      if (optionColumn.name === "cell_id") {
         column = optionColumn;
+        console.log(column.name);
       }
     });
 
@@ -137,8 +136,9 @@ export default function Renderer({ options, data }: any) {
       return {};
     }
 
-    const title = trim(formatSimpleTemplate(column.linkTitleTemplate, prepared));
-    const text = trim(formatSimpleTemplate(column.linkTextTemplate, prepared));
+    const title = trim(formatSimpleTemplate(button.name, prepared));
+
+    const text = trim(formatSimpleTemplate(button.name, prepared));
 
     const result = {
       href,
@@ -146,7 +146,6 @@ export default function Renderer({ options, data }: any) {
       target: button.linkOpenInNewTab ? "_blank" : "_self",
       title: title,
     };
-
     return result;
   }
 
@@ -157,17 +156,19 @@ export default function Renderer({ options, data }: any) {
   };
 
   options.buttonArr.forEach((button: any) => {
-  const { ...props } = prepareLink(selectedData, button);
-  button.props = {...props}
-  })
+    const { ...props } = prepareLink(selectedData, button);
+    button.props = { ...props };
+  });
 
   return (
     <div className="table-visualization-container">
-      {map(options.buttonArr, (button: any, index: any) => <button key={index} className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
-        <a className="link" {...button.props}>
-          {button.name}
-        </a>
-      </button>)}
+      {map(options.buttonArr, (button: any, index: any) => (
+        <button key={index} className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
+          <a className="link" {...button.props}>
+            {button.name}
+          </a>
+        </button>
+      ))}
       <Table
         rowSelection={{ type: "checkbox", ...rowSelection }}
         className="table-fixed-header"

--- a/viz-lib/src/visualizations/selection-table/Renderer.tsx
+++ b/viz-lib/src/visualizations/selection-table/Renderer.tsx
@@ -125,7 +125,6 @@ export default function Renderer({ options, data }: any) {
     options.columns.forEach((optionColumn: Record<string, any>) => {
       if (optionColumn.name === "cell_id") {
         column = optionColumn;
-        console.log(column.name);
       }
     });
 

--- a/viz-lib/src/visualizations/selection-table/Renderer.tsx
+++ b/viz-lib/src/visualizations/selection-table/Renderer.tsx
@@ -119,9 +119,10 @@ export default function Renderer({ options, data }: any) {
     return null;
   }
 
-  function prepareLink(rows: Record<string, any>) {
+  function prepareLink(rows: Record<string, any>, button: any) {
     let column: Record<string, any> = {};
     let prepared = { rows: rows };
+
 
     options.columns.forEach((optionColumn: Record<string, any>) => {
       if (optionColumn.linkUrlTemplate !== "{{ @ }}") {
@@ -131,7 +132,7 @@ export default function Renderer({ options, data }: any) {
 
     prepared = extend({ "@": prepared.rows.map((row: Record<string, any>) => row[column.name]) }, prepared);
 
-    const href = trim(formatSimpleTemplate(column.linkUrlTemplate, prepared));
+    const href = trim(formatSimpleTemplate(button.linkUrlTemplate, prepared));
     if (href === "") {
       return {};
     }
@@ -142,7 +143,7 @@ export default function Renderer({ options, data }: any) {
     const result = {
       href,
       text: text,
-      target: column.linkOpenInNewTab ? "_blank" : "_self",
+      target: button.linkOpenInNewTab ? "_blank" : "_self",
       title: title,
     };
 
@@ -155,12 +156,15 @@ export default function Renderer({ options, data }: any) {
     },
   };
 
-  const { ...props } = prepareLink(selectedData);
+  options.buttonArr.forEach((button: any) => {
+  const { ...props } = prepareLink(selectedData, button);
+  button.props = {...props}
+  })
 
   return (
     <div className="table-visualization-container">
-      {map(options.buttonArr, (button: any, index) => <button key={index} className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
-        <a className="link" {...props}>
+      {map(options.buttonArr, (button: any, index: any) => <button key={index} className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
+        <a className="link" {...button.props}>
           {button.name}
         </a>
       </button>)}

--- a/viz-lib/src/visualizations/selection-table/Renderer.tsx
+++ b/viz-lib/src/visualizations/selection-table/Renderer.tsx
@@ -7,6 +7,7 @@ import Popover from "antd/lib/popover";
 import { RendererPropTypes } from "@/visualizations/prop-types";
 import { formatSimpleTemplate } from "@/lib/value-format";
 
+
 import { prepareColumns, initRows, filterRows, sortRows } from "./utils";
 
 import "./renderer.less";
@@ -158,11 +159,11 @@ export default function Renderer({ options, data }: any) {
 
   return (
     <div className="table-visualization-container">
-      <button className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
+      {map(options.buttonArr, (button: any, index) => <button key={index} className="ant-btn-primary ant-btn" disabled={selectedData.length >= 1 ? false : true}>
         <a className="link" {...props}>
-          Charts
+          {button.name}
         </a>
-      </button>
+      </button>)}
       <Table
         rowSelection={{ type: "checkbox", ...rowSelection }}
         className="table-fixed-header"

--- a/viz-lib/src/visualizations/selection-table/Renderer.tsx
+++ b/viz-lib/src/visualizations/selection-table/Renderer.tsx
@@ -119,16 +119,9 @@ export default function Renderer({ options, data }: any) {
   }
 
   function prepareLink(rows: Record<string, any>, button: any) {
-    let column: Record<string, any> = {};
     let prepared = { rows: rows };
 
-    options.columns.forEach((optionColumn: Record<string, any>) => {
-      if (optionColumn.name === "cell_id") {
-        column = optionColumn;
-      }
-    });
-
-    prepared = extend({ "@": prepared.rows.map((row: Record<string, any>) => row[column.name]) }, prepared);
+    prepared = extend({ "@": prepared.rows.map((row: Record<string, any>) => row[button.columnName]) }, prepared);
 
     const href = trim(formatSimpleTemplate(button.linkUrlTemplate, prepared));
     if (href === "") {

--- a/viz-lib/src/visualizations/selection-table/getOptions.ts
+++ b/viz-lib/src/visualizations/selection-table/getOptions.ts
@@ -4,6 +4,7 @@ import { visualizationsSettings } from "@/visualizations/visualizationsSettings"
 const DEFAULT_OPTIONS = {
   itemsPerPage: 25,
   paginationSize: "default", // not editable through Editor
+  buttonArr: []
 };
 
 const filterTypes = ["filter", "multi-filter", "multiFilter"];


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature


## Description

  - Merged @jisbell347 changes for the Actions Tab in https://github.com/rs21io/snl-battery/tree/SNLBATTERY-28-dynamic-button-on-selection-table
  - Fixed issue with values not updating after changes 
  - Actions state being saved on save
  - Added "Parameters" dropdown that iterates every column in the table's query result 
  - Added link to chart using values under that selected column 

## Related Tickets & Documents

https://rs21inc.atlassian.net/browse/SNLBATTERY-29

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

https://www.loom.com/share/5021b41e261a4179a2776e6ea093268f
